### PR TITLE
Adapting graphify to fit into the `mowgli-in-the-jungle` framework

### DIFF
--- a/graphify.py
+++ b/graphify.py
@@ -6,6 +6,8 @@ from json import dumps
 import spacy
 from tqdm import tqdm
 
+
+# Change this to use the GPU
 CUDA_DEVICE = -1
 COREF_MODEL = "https://s3-us-west-2.amazonaws.com/allennlp/models/coref-model-2018.02.05.tar.gz"
 SRL_MODEL = "https://s3-us-west-2.amazonaws.com/allennlp/models/bert-base-srl-2019.06.17.tar.gz"
@@ -242,7 +244,6 @@ def graphify(sentence: str):
 	return graph
 
 def graphify_dataset(sentences, output_file=None, ):
-        # Change this to use the GPU
         global spacy_parser, coref_predictor, srl_predictor
         
         spacy_parser = spacy.load(SPACY_MODEL, disable=['parser', 'tagger'])

--- a/graphify.py
+++ b/graphify.py
@@ -243,7 +243,7 @@ def graphify(sentence: str):
 			 'edges': edges}
 	return graph
 
-def graphify_dataset(sentences, output_file=None, ):
+def graphify_dataset(sentences, output_file=None):
         global spacy_parser, coref_predictor, srl_predictor
         
         spacy_parser = spacy.load(SPACY_MODEL, disable=['parser', 'tagger'])


### PR DESCRIPTION
Adapting graphify.py to fit into the `mowgli-in-the-jungle` framework, through the following steps:
1. added an intermediate function between main() and graphify() called graphify_dataset(). This function takes a list of sentences, instead of an input file (as in main) or a single sentence (as in graphify). By doing so, we can use graphify on a set of sentences that don't necessarily come from a single file.
2. To make 1. work, I moved some of the global variables to be initialized in graphify_dataset()