### PR TITLE
Remove a print statement

### DIFF
--- a/link.py
+++ b/link.py
@@ -224,7 +224,6 @@ def link(graphs: List,
     for instance in graphs:
         output_instance = instance.copy()
         for uri, node in instance['nodes'].items():
-            print('Current node', uri, node)
             # Extract concept tokens from phrase
             phrase = node['phrase']
             concepts = extraction_fn(phrase, vocab)


### PR DESCRIPTION
Removed a print statement in link() that I introduced for debugging previously, as it resulted in numerous prints, slowing down its execution.